### PR TITLE
Param help fix

### DIFF
--- a/languageExtension/package-lock.json
+++ b/languageExtension/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "aoe2-aiscript-language-extension",
-	"version": "0.1.3-master",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/languageExtension/src/server.ts
+++ b/languageExtension/src/server.ts
@@ -558,7 +558,6 @@ async function getSignatureHelp(textDocPos: TextDocumentPositionParams): Promise
 			return undefined;
 		} else {
 			command_text = command_text_array[0];
-			connection.console.log(command_text_array.join(' | '))
 		}
 
 		command_text     = command_text.substr(1,);	// trim leading '('
@@ -583,17 +582,20 @@ async function getSignatureHelp(textDocPos: TextDocumentPositionParams): Promise
 			
 			// Load the parameters with descriptions
 			let par_info : ParameterInformation[] = [];
+			let offset = command_str.length + 1;
 			command.pars.forEach(par => {
 				if (par.type !== "none") {
 					command_str += " " + par.type;
 					par_info.push({
-						label: par.type,
+						label: [offset, offset+par.type.length],
 						documentation: {
 							value: "**"+par.type +":** *"+par.note+"*", 
 							kind: 'markdown'
 						}
 					});
+					offset += par.type.length+1;
 				}
+				
 			});
 
 			let descrip: MarkupContent = {value: "", kind: 'markdown'};

--- a/languageExtension/src/server.ts
+++ b/languageExtension/src/server.ts
@@ -19,7 +19,8 @@ import {
 	Hover,
 	Range,
 	SignatureHelp,
-	ParameterInformation
+	ParameterInformation,
+	MarkupContent
 } from 'vscode-languageserver';
 
 // Import the needed methods and objects
@@ -109,7 +110,7 @@ interface AiScriptSettings {
 	updateErrorsWhen: string;			// Specifies when to update Errors
 	enableCompletionHelp: boolean;		// Turns on/off completion suggestions
 	enableHoverHelp:      boolean;		// Turns on/off hover help
-	enableParameterHelp:  boolean;		// Turns on/off signature help
+	enableParameterHelp:  string;		// Turns on/off signature help
 }
 
 /**********************************************************************//**
@@ -120,7 +121,7 @@ const defaultSettings: AiScriptSettings = {
 	updateErrorsWhen: "onSave",
 	enableCompletionHelp: false,
 	enableHoverHelp: false,
-	enableParameterHelp: false
+	enableParameterHelp: "parametersOnly"
 };
 let globalSettings: AiScriptSettings = defaultSettings;
 
@@ -404,7 +405,6 @@ async function getHover(textDocPos: TextDocumentPositionParams): Promise<Hover> 
 	let comment_regex = /;/g;
 	if (comment_regex.test(line_text.substr(0,col))) {
 		hover = undefined;
-		connection.console.log("Hovering on a comment");
 	}
 
 	// ... otherwise get the string
@@ -492,7 +492,7 @@ connection.onSignatureHelp(
 async function getSignatureHelp(textDocPos: TextDocumentPositionParams): Promise<SignatureHelp> {
 	// Make sure we actually want parameter help
 	let settings = await getDocumentSettings(textDocPos.textDocument.uri);
-	if (settings.enableParameterHelp === false) {
+	if (settings.enableParameterHelp === "off") {
 		return undefined;
 	}
 																
@@ -558,6 +558,7 @@ async function getSignatureHelp(textDocPos: TextDocumentPositionParams): Promise
 			return undefined;
 		} else {
 			command_text = command_text_array[0];
+			connection.console.log(command_text_array.join(' | '))
 		}
 
 		command_text     = command_text.substr(1,);	// trim leading '('
@@ -588,21 +589,23 @@ async function getSignatureHelp(textDocPos: TextDocumentPositionParams): Promise
 					par_info.push({
 						label: par.type,
 						documentation: {
-							value: "**"+par.type +":** *"+par.note+"*\n\n----", 
+							value: "**"+par.type +":** *"+par.note+"*", 
 							kind: 'markdown'
 						}
 					});
 				}
 			});
 
+			let descrip: MarkupContent = {value: "", kind: 'markdown'};
+			if (settings.enableParameterHelp === "full") {
+				descrip.value = "\n----\n**Command Description**  \n"+command.description;
+			}
+
 			// Initialize the signature object
 			signature = {
 				signatures: [{
 					label: command_str,
-					documentation: {
-						value: "**Command Description**  \n"+command.description, 
-						kind: 'markdown'
-					},
+					documentation: descrip,
 					parameters: par_info
 				}],
 				activeSignature: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "aoe2-aiscript",
-    "version": "0.1.4",
+    "version": "0.2.0-dev",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,12 +66,13 @@
                 },
                 "aoe2_AiScript.enableParameterHelp": {
                     "scope": "resource",
-                    "type": "boolean",
+                    "type": "string",
                     "enum": [
-                        true,
-                        false
+                        "off",
+                        "parametersOnly",
+                        "full"
                     ],
-                    "default": false,
+                    "default": "parametersOnly",
                     "description": "Controls whether parameter help will be provided as you write commands."
                 },
                 "aoe2_AiScript.enableHoverHelp": {


### PR DESCRIPTION
Fixes #8 and introduces multiple levels of parameter help text:

- `off`: Turns off parameter help
- `parametersOnly`: Only the command signature and the current parameter help text are displayed
- `full`: Displays all help text about the current parameter and the current command